### PR TITLE
visualize diagnostics in floating window with lead+d

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -541,6 +541,14 @@ require("lazy").setup({
 			})
 
 			-- Diagnostic Config
+			-- Show all diagnostics on current line in floating window
+			vim.api.nvim_set_keymap(
+				"n",
+				"<Leader>d",
+				":lua vim.diagnostic.open_float()<CR>",
+				{ noremap = true, silent = true }
+			)
+			vim.diagnostic.open_float()
 			-- See :help vim.diagnostic.Opts
 			vim.diagnostic.config({
 				severity_sort = true,


### PR DESCRIPTION
Diagnostic errors tend to be cut if they are longer than window size.

This solution shows the message in a floating window when pressing leader+d